### PR TITLE
Don't hardcode option name in uninstaller

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -15,6 +15,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 // Delete all options that contain gem.
 delete_option( 'gem-valid-creds' );
 delete_option( 'gem-version' );
-delete_option( 'gem-settings' );
+delete_option( GEM_Settings::SLUG );
 
 // @codeCoverageIgnoreEnd


### PR DESCRIPTION
We should be referencing the constant inside `GEM_Settings` for the settings option name.