### PR TITLE
Rename plugin to match search results

### DIFF
--- a/godaddy-email-marketing.php
+++ b/godaddy-email-marketing.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: GoDaddy Email Marketing Signup Forms
+ * Plugin Name: GoDaddy Email Marketing
  * Plugin URI: https://gem.godaddy.com/
  * Description: Add the GoDaddy Email Marketing signup form to your WordPress site! Easy to set up, the plugin allows your site visitors to subscribe to your email lists.
  * Version: 1.1.4


### PR DESCRIPTION
The plugin name is "GoDaddy Email Marketing" in the `readme.txt` that is used for WordPress.org and plugin search results, but it is "GoDaddy Email Marketing Signup Forms" after installing it. Better to be consistent here and the shorter title should win.