### PR TITLE
Fix cache being bypassed when fetching forms

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -85,7 +85,7 @@ class GEM_Blocks {
 	 */
 	private function get_forms() {
 
-		$forms = GEM_Dispatcher::fetch_forms();
+		$forms = GEM_Dispatcher::get_forms();
 
 		if ( empty( $forms->signups ) ) {
 


### PR DESCRIPTION
This PR resolves excessive API requests.

- `fetch_forms()` clears the cache and fetches fresh data.
- `get_forms()` checks for the existence of cached data and returns that if exists, else it calls `fetch_forms()`.