### PR TITLE
Fix help tab iframe URL for non-US locales

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -559,7 +559,7 @@ class GEM_Settings {
 
 		}
 
-		$subdomain = 'us' ? '' : $subdomain . '.';
+		$subdomain = $subdomain == 'us' ? '' : $subdomain . '.';
 
 		?>
 		<iframe src="<?php echo esc_url( "https://{$subdomain}godaddy.com/help/godaddy-email-marketing-1000013" ); ?>" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
It looks like this new ternary expression will always remove the subdomain because `'us'?` will always resolve as true. This PR fixes the ternary, but honestly it looks like the default used to use a subdomain of `www` and if you continue to do that you could simply integrate this fix into the existing `switch` statement. I'll open a separate PR with that fix and you can choose which one you prefer. 